### PR TITLE
package.json: comma after the last key value pair causes heroku to fa…

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "ejs": "^2.5.5",
-    "express": "^4.14.0",
+    "express": "^4.14.0"
   },
   "devDependencies": {
     "eslint-plugin-html": "^1.7.0"


### PR DESCRIPTION
package.json: comma after the last key value pair causes heroku to fail when compiling the application. Remove the comma.